### PR TITLE
Fix lowering to LLVM

### DIFF
--- a/include/Transforms/Pipeline.h
+++ b/include/Transforms/Pipeline.h
@@ -4,7 +4,7 @@
 namespace sblp {
 
 void registerLoopOptimizationPipeline();
-void registerMLIRToLLVMPipeline();
+void registerLowerToLLVMPipeline();
 
 } // namespace sblp
 

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -4,13 +4,15 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/env_check.sh"
 
 ./build/bin/sblp-opt examples/matmul.mlir \
---one-shot-bufferize="bufferize-function-boundaries" \
---convert-linalg-to-loops \
---convert-scf-to-cf \
---convert-cf-to-llvm \
---convert-arith-to-llvm \
---convert-func-to-llvm \
---convert-index-to-llvm \
---finalize-memref-to-llvm \
---reconcile-unrealized-casts | \
+  --one-shot-bufferize="bufferize-function-boundaries" \
+  --convert-linalg-to-loops \
+  --convert-scf-to-cf \
+  --convert-cf-to-llvm \
+  --expand-strided-metadata \
+  --lower-affine \
+  --convert-arith-to-llvm \
+  --convert-index-to-llvm \
+  --convert-func-to-llvm \
+  --finalize-memref-to-llvm \
+  --reconcile-unrealized-casts | \
 mlir-runner -e main -entry-point-result=void -shared-libs=$LLVM_BUILD_DIR/lib/libmlir_runner_utils.so

--- a/tools/sblp-opt.cpp
+++ b/tools/sblp-opt.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 
   sblp::registerStrengthReductionPass();
   sblp::registerLoopOptimizationPipeline();
-  sblp::registerMLIRToLLVMPipeline();
+  sblp::registerLowerToLLVMPipeline();
   sblp::registerGCDTilingPass();
 
   mlir::DialectRegistry registry;


### PR DESCRIPTION
- Fixed pipeline which lowers to `llvm` dialect, which was broken after #6 
- Changed the name of the pipeline to `lower-to-llvm`, which better conveys the intent of lowering to the `llvm` MLIR dialect, and not to LLVM IR
- Updated the `run_example.sh` script to reflect the changes in the lowering pipeline