### PR TITLE
Some headers and link targets changes on the newer version of LLVM. F…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We haven't tested running this code on Windows, therefore we recommend using Lin
 
 | Dependency | Version   | Installation Link                                                   |
 |------------|-----------|---------------------------------------------------------------------|
-| LLVM       |  = 21     | [llvm.org](https://llvm.org/docs/CMake.html)                        |
+| LLVM       | == 21     | [llvm.org](https://llvm.org/docs/CMake.html)                        |
 | Python     | >= 3.10   | [python.org](https://www.python.org/downloads/release/python-3100/) |
 | CMake      | >= 3.20   | [cmake.org](https://cmake.org/install/)                             |
 | Ninja      | >= 1.10   | [ninja-build GitHub](https://github.com/ninja-build/ninja/releases) |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We haven't tested running this code on Windows, therefore we recommend using Lin
 
 | Dependency | Version   | Installation Link                                                   |
 |------------|-----------|---------------------------------------------------------------------|
-| LLVM       | >= 21     | [llvm.org](https://llvm.org/docs/CMake.html)                        |
+| LLVM       |  = 21     | [llvm.org](https://llvm.org/docs/CMake.html)                        |
 | Python     | >= 3.10   | [python.org](https://www.python.org/downloads/release/python-3100/) |
 | CMake      | >= 3.20   | [cmake.org](https://cmake.org/install/)                             |
 | Ninja      | >= 1.10   | [ninja-build GitHub](https://github.com/ninja-build/ninja/releases) |


### PR DESCRIPTION
Some headers and link targets changes on the newer version of LLVM. Fixing LLVM Dependencies to Version 21.

The include header at [Pipeline.cpp](https://github.com/rafasumi/mlir-tutorial/blob/0c9e92a7dfe23c643147dc866bfb1d7025c79cda/lib/Transforms/Pipeline.cpp#L12) was changes to "mlir/Dialect/Affine/Transforms/Passes.h" path.

And on [tools/CMakeLists.txt](https://github.com/rafasumi/mlir-tutorial/blob/0c9e92a7dfe23c643147dc866bfb1d7025c79cda/tools/CMakeLists.txt#L18) we need to add `MLIRRegisterAllPasses` and  `MLIRRegisterAllDialects` to sblp-opt target link libraries. 

Since other changes like this can happen on furthers version, i fixed the LLVM Dependence to Version 21.